### PR TITLE
Remove unneeded dependencies and relax version upper bounds 

### DIFF
--- a/serdoc-binary/serdoc-binary.cabal
+++ b/serdoc-binary/serdoc-binary.cabal
@@ -43,4 +43,4 @@ test-suite serdoc-binary-test
                  , binary >=0.8.0.0 && <0.11
                  , bytestring >=0.11 && <0.13
                  , tasty >=1.5 && <1.6
-                 , tasty-quickcheck >=0.10.3 && <0.11
+                 , tasty-quickcheck >=0.10.3 && <0.12

--- a/serdoc-binary/serdoc-binary.cabal
+++ b/serdoc-binary/serdoc-binary.cabal
@@ -42,8 +42,5 @@ test-suite serdoc-binary-test
                  , serdoc-core ^>=0.3.0.0
                  , binary >=0.8.0.0 && <0.11
                  , bytestring >=0.11 && <0.13
-                 , mtl >=2.3.1 && <2.4
                  , tasty >=1.5 && <1.6
                  , tasty-quickcheck >=0.10.3 && <0.11
-                 , text >=1.1 && <2.2
-                 , time >=1.12 && <1.14

--- a/serdoc-core/serdoc-core.cabal
+++ b/serdoc-core/serdoc-core.cabal
@@ -33,7 +33,7 @@ library
                    , Data.SerDoc.TH
     build-depends: base >=4.14.0.0 && <5
                  , bytestring >=0.11 && <0.13
-                 , containers >=0.6 && <0.8
+                 , containers >=0.6 && <0.9
                  , text >=1.1 && <2.2
                  , template-haskell >=2.16 && <2.24
                  , th-abstraction >=0.6 && <0.7
@@ -55,4 +55,4 @@ test-suite serdoc-test
                  , bytestring >=0.11 && <0.13
                  , mtl >=2.3.1 && <2.4
                  , tasty >=1.5 && <1.6
-                 , tasty-quickcheck >=0.10.3 && <0.11
+                 , tasty-quickcheck >=0.10.3 && <0.12

--- a/serdoc-core/serdoc-core.cabal
+++ b/serdoc-core/serdoc-core.cabal
@@ -34,11 +34,7 @@ library
     build-depends: base >=4.14.0.0 && <5
                  , bytestring >=0.11 && <0.13
                  , containers >=0.6 && <0.8
-                 , mtl >=2.3.1 && <2.4
-                 , tasty >=1.5 && <1.6
-                 , tasty-quickcheck >=0.10.3 && <0.11
                  , text >=1.1 && <2.2
-                 , time >=1.12 && <1.14
                  , template-haskell >=2.16 && <2.24
                  , th-abstraction >=0.6 && <0.7
     hs-source-dirs:   src
@@ -60,6 +56,3 @@ test-suite serdoc-test
                  , mtl >=2.3.1 && <2.4
                  , tasty >=1.5 && <1.6
                  , tasty-quickcheck >=0.10.3 && <0.11
-                 , template-haskell >=2.16 && <2.24
-                 , text >=1.1 && <2.2
-                 , time >=1.12 && <1.14


### PR DESCRIPTION
- Removes `serdoc-core`'s unneeded dependencies on `mtl`, `tasty`, `tasty-quickcheck`, `template-haskell`, and `time`
- Removes `serdoc-binary`'s unneeded dependencies on `mtl`, `text`, and `time`
- Relaxes version upper bounds for `containers` and `tasty-quickcheck`